### PR TITLE
Update the README, since the bleeding edge version isn't required anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This repository hosts a series of JSON files written for the `underanalyzer` branch of [UndertaleModTool](https://github.com/UnderminersTeam/UndertaleModTool/tree/underanalyzer). It is intended to make Pizza Tower modding easier by correctly resolving assets. Collaboration is always appreciated, so feel free to open a pull request or two! :D
 
 # How To Install
-1. [Download](https://github.com/UnderminersTeam/UndertaleModTool/releases) the latest stable or bleeding edge version of UndertaleModTool (v0.8.0.0 or later).
+1. [Download](https://github.com/UnderminersTeam/UndertaleModTool/releases) the latest stable or nightly version of UndertaleModTool (v0.8.0.0 or later).
 2. Get a copy of this repository. I'd recommend using GitHub's ZIP download for easy install, but it's up to you how.
 3. In the folder containing the UTMT build, merge the `GameSpecificData` folder from this repository into the one there.
 4. You're done! Launch UTMT from there and the next time you open up Pizza Tower, the changes should be applied!

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This repository hosts a series of JSON files written for the `underanalyzer` branch of [UndertaleModTool](https://github.com/UnderminersTeam/UndertaleModTool/tree/underanalyzer). It is intended to make Pizza Tower modding easier by correctly resolving assets. Collaboration is always appreciated, so feel free to open a pull request or two! :D
 
 # How To Install
-1. [Download](https://github.com/UnderminersTeam/UndertaleModTool/releases/tag/bleeding-edge) the latest Bleeding Edge version of UndertaleModTool.
+1. [Download](https://github.com/UnderminersTeam/UndertaleModTool/releases) the latest stable or bleeding edge version of UndertaleModTool (v0.8.0.0 or later).
 2. Get a copy of this repository. I'd recommend using GitHub's ZIP download for easy install, but it's up to you how.
 3. In the folder containing the UTMT build, merge the `GameSpecificData` folder from this repository into the one there.
 4. You're done! Launch UTMT from there and the next time you open up Pizza Tower, the changes should be applied!


### PR DESCRIPTION
it used to be when v0.8.0.0 didn't exist and the Underanalyzer (de)compiler was only in the bleeding edge version, but now release versions can be used